### PR TITLE
Add Dockerfiles for OpenSearch container builds

### DIFF
--- a/opensearch-dashboards/Dockerfile
+++ b/opensearch-dashboards/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/opensearchproject/opensearch-dashboards:1.2.0
+USER 0
+
+# usermod chowns the uid of files, but not the gid - we chown both later
+# in one pass, so change the home dir here to prevent duplicated effort
+RUN usermod -d /tmp/home/opensearch-dashboards opensearch-dashboards
+RUN groupmod -g 4005 opensearch-dashboards
+RUN usermod -u 4005 -g 4005 opensearch-dashboards
+RUN usermod -d /usr/share/opensearch-dashboards opensearch-dashboards
+
+RUN chown -R opensearch-dashboards:opensearch-dashboards /usr/share/opensearch-dashboards
+
+USER 4005

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/opensearchproject/opensearch:1.2.4
+USER 0
+
+# usermod chowns the uid of files, but not the gid - we chown both later
+# in one pass, so change the home dir here to prevent duplicated effort
+RUN usermod -d /tmp/home/opensearch opensearch
+RUN groupmod -g 4005 opensearch
+RUN usermod -u 4005 -g 4005 opensearch
+RUN usermod -d /usr/share/opensearch opensearch
+
+RUN chown -R opensearch:opensearch /usr/share/opensearch
+
+USER 4005


### PR DESCRIPTION
The base images are currently version-locked for initial builds and deployment. We will move to using the `latest` tag in the future.

These Dockerfiles also contain hardcoded `uid`s and `gid`s, which could be improved upon.