### PR TITLE
Bump base images to 1.3.4

### DIFF
--- a/opensearch-dashboards/Dockerfile
+++ b/opensearch-dashboards/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opensearchproject/opensearch-dashboards:1.2.0
+FROM docker.io/opensearchproject/opensearch-dashboards:1.3.4
 USER 0
 
 # usermod chowns the uid of files, but not the gid - we chown both later

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opensearchproject/opensearch:1.2.4
+FROM docker.io/opensearchproject/opensearch:1.3.4
 USER 0
 
 # usermod chowns the uid of files, but not the gid - we chown both later


### PR DESCRIPTION
Increase base image versions to 1.3.4, the latest release of OpenSearch/OpenSearch Dashboards 1.3.